### PR TITLE
Make bddcml_interface_fortran.f90 a module

### DIFF
--- a/examples/bddcml_global.f90
+++ b/examples/bddcml_global.f90
@@ -23,6 +23,7 @@ program bddcml_global
       use module_pp
 ! Program name
       use module_utils
+      use bddcml_interface_fortran
 
       implicit none
       

--- a/examples/bddcml_local.f90
+++ b/examples/bddcml_local.f90
@@ -25,6 +25,7 @@ program bddcml_local
       use module_sm
 ! Program name
       use module_utils
+      use bddcml_interface_fortran
 
       implicit none
       

--- a/examples/poisson_on_cube.f90
+++ b/examples/poisson_on_cube.f90
@@ -28,6 +28,7 @@ program poisson_on_cube
       use module_utils
 ! functions for exporting to ParaView format
       use module_paraview
+      use bddcml_interface_fortran
 
       implicit none
       

--- a/src/bddcml_interface_fortran.f90
+++ b/src/bddcml_interface_fortran.f90
@@ -14,6 +14,10 @@
 ! <http://www.gnu.org/copyleft/lesser.html>.
 !________________________________________________________________
 
+module bddcml_interface_fortran
+implicit none
+
+contains
 
 ! Interface providing Fortran functions that may be called from applications
 ! to exploit multilevel adaptive BDDC solver 
@@ -728,3 +732,4 @@ subroutine bddcml_finalize
       call krylov_finalize
 end subroutine
 
+end module


### PR DESCRIPTION
Now one can use it in other programs and the compiler checks argument types.
